### PR TITLE
Objets d'image vides après serialisation

### DIFF
--- a/lib/model/ExtractedImage.php
+++ b/lib/model/ExtractedImage.php
@@ -67,9 +67,9 @@ class ExtractedImage implements ArrayAccess
       */
     protected static $swaggerTypes = array(
         'type' => 'string',
-        'image_dl' => 'string[]',
-        'image_ir' => 'string[]',
-        'image_uv' => 'string[]',
+        'image_dl' => 'string',
+        'image_ir' => 'string',
+        'image_uv' => 'string',
         'page' => 'int',
         'indicators' => '\model\ImageIndicator[]'
     );


### PR DESCRIPTION
Bonjour,

Dans le cadre de l'intégration de votre librairie pour Lydia, je suis tombé sur un bug qui faisait que les images ne ressortaient pas après serialisation.
Structurellement, le json retourne une string pour 'image_dl', 'image_ir' et 'image_uv'.

Bien à vous.